### PR TITLE
Pass type to `logLevel`

### DIFF
--- a/src/Classes/ConsoleJavascriptLogger.ts
+++ b/src/Classes/ConsoleJavascriptLogger.ts
@@ -10,7 +10,7 @@ export class ConsoleJavascriptLogger extends JavascriptLogger<object> {
 		this._minimumLevel = logLevel ?? LogLevel.warn;
 	}
 
-	logLevel = (): LogLevel => this._minimumLevel;
+	logLevel = (_extraDetails?: object): LogLevel => this._minimumLevel;
 
 	logIt = (logLevel: LogLevel, title: string, message?: string | string[], extraDetails?: object): void => {
 		switch (logLevel) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,10 @@ import { LogLevel } from './Enumerators/LogLevel';
 
 export abstract class JavascriptLogger<T> {
 	abstract logIt(logLevel: LogLevel, title: string, message?: string | string[], extraDetails?: T): void;
-	abstract logLevel(): LogLevel;
+	abstract logLevel(extraDetails?: T): LogLevel;
 
 	log = (logLevel: LogLevel, title: string, message?: string[] | string, extraDetails?: T): void => {
-		if (logLevel <= this.logLevel()) {
+		if (logLevel <= this.logLevel(extraDetails)) {
 			this.logIt(logLevel, title, message, extraDetails);
 		}
 	};


### PR DESCRIPTION
To allow a user to calculate the `LogLevel` using an argument that's relative at the time. It can now be included in the `extraDetails` object which is now passed to the `logLevel` function.